### PR TITLE
Enable build for py3k win

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: True  # [win and py3k]
 
 requirements:
   build:


### PR DESCRIPTION
As far as I can tell there, pangaea should work on windows. If there is a reason not to build, we can leave this open while I fix pangaea to build on windows. If merged this will close #1 